### PR TITLE
fix: correct CI test failures (org dash macro, with-db macro, timeout)

### DIFF
--- a/lisp/agent-shell-queue-org.el
+++ b/lisp/agent-shell-queue-org.el
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+(require 'seq)
 (require 'agent-shell-queue)
 (require 'org)
 (require 'org-element)
@@ -43,7 +44,7 @@
   "Alist mapping queue status symbols to org TODO keyword strings.")
 
 (defconst agent-shell-queue-org--keyword-status
-  (--map (cons (cdr it) (car it)) agent-shell-queue-org--status-keyword)
+  (seq-map (lambda (it) (cons (cdr it) (car it))) agent-shell-queue-org--status-keyword)
   "Reverse alist: org TODO keyword strings to queue status symbols.")
 
 ;;; Shared helpers
@@ -178,7 +179,7 @@ Must be called in the buffer where ITEM-HL was parsed."
 
 (defun agent-shell-queue-org--headlines-of (element)
   "Return the direct headline children of ELEMENT as a list."
-  (--filter (eq (org-element-type it) 'headline) (org-element-contents element)))
+  (seq-filter (lambda (it) (eq (org-element-type it) 'headline)) (org-element-contents element)))
 
 (defun agent-shell-queue-org--deserialize (str)
   "Deserialize STR (org format) into an items alist via org-element.

--- a/lisp/tychoish-bootstrap.el
+++ b/lisp/tychoish-bootstrap.el
@@ -2042,12 +2042,12 @@ magit process buffer for that submodule."
 (defun tychoish/run-ci-tests (&optional timeout)
   "Discover and run all ERT tests under test/, then exit.
 Intended for CI invocations via --fg-daemon --eval.
-Installs a TIMEOUT-second kill guard (default 60) before running."
+Installs a TIMEOUT-second kill guard (default 240) before running."
   (let ((test-dir (expand-file-name "test" user-emacs-directory))
         (noninteractive t))
     (add-to-list 'load-path test-dir)
     (load (expand-file-name "test-helper" test-dir) nil t)
-    (run-with-timer (or timeout 60) nil (lambda () (kill-emacs 1)))
+    (run-with-timer (or timeout 240) nil (lambda () (kill-emacs 1)))
     (condition-case err
         (dolist (file (directory-files test-dir t "\\`test-.*\\.el\\'"))
           (load file nil t))

--- a/test/test-agent-shell-queue-db.el
+++ b/test/test-agent-shell-queue-db.el
@@ -26,36 +26,35 @@
 (defmacro agent-shell-queue-db-test/with-db (&rest body)
   "Run BODY with isolated queue globals and a fresh temporary SQLite database.
 Opens a new connection to a temp file, runs BODY, then closes the connection
-and deletes the temp file regardless of whether BODY signals an error."
+and deletes the temp file regardless of whether BODY signals an error.
+Skips the enclosing test when built-in sqlite is unavailable."
   (declare (indent 0))
-  `(agent-shell-queue-db-test/skip-if-no-sqlite)
-  `(let* ((db-path (make-temp-file "aq-db-test-" nil ".db"))
-          (agent-shell-queue-db-file db-path)
-          (agent-shell-queue-db--connection nil)
-          (agent-shell-queue--items nil)
-          (agent-shell-queue--loaded t)
-          (agent-shell-queue--subscriptions nil)
-          (agent-shell-queue--editing-ids nil)
-          (agent-shell-queue--session-paused nil)
-          (agent-shell-queue--stale-item-ids nil)
-          (agent-shell-queue-paused nil)
-          (agent-shell-queue--last-flush-time nil)
-          (agent-shell-queue--next-flush-time nil)
-          (agent-shell-queue-save-function nil)
-          (agent-shell-queue-load-function nil)
-          (agent-shell-queue-state-file-function
-           #'agent-shell-queue--default-state-file)
-          (agent-shell-queue-db--saved-save-function nil)
-          (agent-shell-queue-db--saved-load-function nil)
-          (agent-shell-queue-db--saved-state-file-function nil))
-     (cl-letf (((symbol-function 'agent-shell-queue--refresh-buffer) #'ignore)
-               ((symbol-function 'agent-shell-queue--ensure-subscription) #'ignore)
-               ((symbol-function 'agent-shell-queue--drop-subscription) #'ignore)
-               ((symbol-function 'alert) #'ignore))
-       (unwind-protect
-           (progn ,@body)
-         (agent-shell-queue-db--close)
-         (when (file-exists-p db-path) (delete-file db-path))))))
+  `(progn
+     (skip-unless (fboundp 'sqlite-open))
+     (let* ((db-path (make-temp-file "aq-db-test-" nil ".db"))
+            (agent-shell-queue-db-file db-path)
+            (agent-shell-queue-db--connection nil)
+            (agent-shell-queue--items nil)
+            (agent-shell-queue--loaded t)
+            (agent-shell-queue--subscriptions nil)
+            (agent-shell-queue--stale-item-ids nil)
+            (agent-shell-queue--last-flush-time nil)
+            (agent-shell-queue--next-flush-time nil)
+            (agent-shell-queue-save-function nil)
+            (agent-shell-queue-load-function nil)
+            (agent-shell-queue-state-file-function
+             #'agent-shell-queue--default-state-file)
+            (agent-shell-queue-db--saved-save-function nil)
+            (agent-shell-queue-db--saved-load-function nil)
+            (agent-shell-queue-db--saved-state-file-function nil))
+       (cl-letf (((symbol-function 'agent-shell-queue--refresh-buffer) #'ignore)
+                 ((symbol-function 'agent-shell-queue--ensure-subscription) #'ignore)
+                 ((symbol-function 'agent-shell-queue--drop-subscription) #'ignore)
+                 ((symbol-function 'alert) #'ignore))
+         (unwind-protect
+             (progn ,@body)
+           (agent-shell-queue-db--close)
+           (when (file-exists-p db-path) (delete-file db-path)))))))
 
 (defun agent-shell-queue-db-test/make-item (id prompt &optional status background kind)
   "Build a deterministic test item with fixed timestamps."
@@ -584,6 +583,7 @@ reached.  This test documents the actual behaviour."
 
 (ert-deftest agent-shell-queue-db/enable-with-explicit-file ()
   "db-enable with a file argument sets `agent-shell-queue-db-file'."
+  (skip-unless (fboundp 'sqlite-open))
   (let* ((tmp (make-temp-file "aq-enable-test-" nil ".db"))
          (agent-shell-queue-db-file nil)
          (agent-shell-queue-db--connection nil)


### PR DESCRIPTION
Three bugs were causing CI test failures across the unit and integration test jobs.

## Bug 1: `agent-shell-queue-org.el` — dash macro at load time without `require 'dash`

`agent-shell-queue-org.el` used the dash anaphoric macro `--map` inside a top-level `defconst` without ever `(require 'dash)`. When `ert-runner` processes test files alphabetically, `test-agent-shell-queue-org.el` is loaded before `test-builder.el` or `test-tychoish-bootstrap.el` (the files that transitively bring in dash via xtdlib). This caused:

```
Symbol's function definition is void: --map
```

Fixed by replacing `--map`/`--filter` with `seq-map`/`seq-filter` equivalents and adding `(require 'seq)`.

## Bug 2: `test/test-agent-shell-queue-db.el` — broken `with-db` macro and missing skip guards

The `with-db` test isolation macro had **two separate backquote forms** in its body. In Emacs Lisp, a function returns only its last evaluated form — so the `(skip-unless (fboundp 'sqlite-open))` form was dead code and never included in the macro expansion. When SQLite is unavailable (e.g. non-sqlite Emacs builds), tests would **fail** instead of **skip**.

Additionally:
- Three `let*` bindings in `with-db` targeted struct fields (`editing-ids`, `session-paused`, `paused`) rather than `defvar`'d symbols. In lexical-binding mode these create inert lexical variables, not dynamic bindings, so they were misleading. They are removed.
- The standalone `agent-shell-queue-db/enable-with-explicit-file` test called `agent-shell-queue-db-enable` (which hard-errors when sqlite is absent) without a `skip-unless` guard.

Fixed by combining both backquote forms into a single `(progn ...)`, inlining the skip check directly, and adding the missing guard to the standalone test.

## Bug 3: `tychoish/run-ci-tests` — default kill timer too short

The integration test function installed a 60-second kill timer before loading ~13 test files and running ~830 tests. In slower CI environments (cold caches, I/O contention) this window is too tight and Emacs exits with code 1 before the test runner finishes normally.

Increased the default from 60 → 240 seconds, consistent with the 5-minute job-level `timeout-minutes` already in the workflow.

https://claude.ai/code/session_01DqCvURR4tv2zBEioMUtASM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqCvURR4tv2zBEioMUtASM)_